### PR TITLE
Enlarge command container

### DIFF
--- a/src/sass/base/_common.scss
+++ b/src/sass/base/_common.scss
@@ -142,16 +142,17 @@ pre {
     border-left: 5px solid $preBlockBorderColor;
     border-radius: 4px;
     box-shadow: 3px 3px 8px $preBlockShadowColor;
-	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	word-wrap: normal;
-	line-height: 1.5;
-	tab-size: 4;
-	hyphens: none;
-	background: $preBlockBackgroundColor;
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
+    tab-size: 4;
+    hyphens: none;
+    background: $preBlockBackgroundColor;
+    display: flex;
 
     code {
         display: block;
@@ -166,19 +167,19 @@ pre {
         padding: 0;
 
         .command {
-            padding: .5em .5em 0 .5em;
+            padding: 1.5em 1em;
         }
 
         .output {
             color: $preBlockCommandOutputTextColor;
             background-color: $preBlockCommandOutputBackgroundColor;
             font-style: italic;
-            padding: 0 .5em .5em .5em;
+            padding: 1em;
         }
 
         // if the output div is empty, we need extra padding
         div:only-of-type {
-            padding: .5em;
+            padding: 1.5em 1em;
         }
     }
 


### PR DESCRIPTION
Make command container larger so it can be scrolled in phones easily.
Fix background color when output is wider than screen (commands).

It was almost impossible to scroll in mobile devices due to the small size.

**Without output**
_Before_
![istio_before](https://user-images.githubusercontent.com/10326536/44620562-be88d780-a896-11e8-8da6-bbbff85f0de9.png)
_After_
![istio_after](https://user-images.githubusercontent.com/10326536/44620567-d5c7c500-a896-11e8-8272-08e9d9f62a9a.png)

**With output**
_Before_
![istio_multi_before](https://user-images.githubusercontent.com/10326536/44620571-09a2ea80-a897-11e8-99c5-dbdb873c4472.png)
_After_
![istio_multi_after](https://user-images.githubusercontent.com/10326536/44620572-0ad41780-a897-11e8-8cce-231a7b3fa076.png)
